### PR TITLE
Seela, 24.02. handling pipes and redrections correctly

### DIFF
--- a/include/seela.h
+++ b/include/seela.h
@@ -8,6 +8,8 @@
 # include <stdio.h>
 # include "../libft/include/libft.h"
 # include <errno.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 
 typedef struct s_ms
 {
@@ -101,5 +103,6 @@ void	redirection_outfile_emptied(char *file); //< HANDLING
 void	redirection_infile(char *file); //> HANDLING
 void	redirection_outfile_append(char *file); //<< HANDLING
 void    handle_heredoc(char *limiter); //>> HANDLNG
+void	put_heredoc_fd(t_token *token, t_cmd *cmd);
 
 #endif

--- a/src/execution/execute_cmd.c
+++ b/src/execution/execute_cmd.c
@@ -112,6 +112,12 @@ void	execute_single_cmd(t_cmd *cmd, t_ms *ms) ///t_token *token?
 				exit(1);
 			close(cmd->infile);
 		}
+		if (cmd->outfile != -2 && cmd->outfile != -1)
+		{
+			if (dup2(cmd->outfile, STDOUT_FILENO) == -1)
+				exit(1);
+			close(cmd->outfile);
+		}
 		if (is_builtin(cmd))
 		{
 			handle_builtin(cmd, ms, 0);

--- a/src/execution/execute_cmd.c
+++ b/src/execution/execute_cmd.c
@@ -28,7 +28,7 @@ ALSO WORKS WITH SINGLE COMMAND EXECUTION SO CALL THIS WHENEVER YOU NEED TO EXECU
 //include "seela.h"
 #include "../../include/minishell.h"
 
-static void	pipe_process(int *prev_pipe, int *next_pipe)
+/*static void	pipe_process(int *prev_pipe, int *next_pipe)
 {
 	if (prev_pipe)
 	{
@@ -44,21 +44,53 @@ static void	pipe_process(int *prev_pipe, int *next_pipe)
 		close(next_pipe[0]);
 		close(next_pipe[1]);
 	}
+}*/
+
+static void	pipe_process(int infile, int outfile, int *prev_pipe, int *next_pipe)
+{
+	if (prev_pipe)
+	{
+		if (dup2(prev_pipe[0], STDIN_FILENO) == -1) //It duplicates previous pipes read-end to stadard input
+			exit(1);
+		close(prev_pipe[0]);
+		close(prev_pipe[1]);
+	}
+	if (infile != -2 && infile != -1) 
+	{
+		if (dup2(infile, STDIN_FILENO) == -1) //It duplicates previous pipes read-end to stadard input
+			exit(1);
+		close(infile);
+	}
+	if (next_pipe)
+	{
+		if (dup2(next_pipe[1], STDOUT_FILENO) == -1) //It duplicates the next pipes write-end to standard output
+			exit(1);
+		close(next_pipe[0]);
+		close(next_pipe[1]);
+	}
+	if (outfile != -2 && outfile != -1)
+	{
+		if (dup2(outfile, STDOUT_FILENO) == -1) //It duplicates the next pipes write-end to standard output
+			exit(1);
+		close(outfile);
+
+	}
 }
 
-void	execute_single_cmd(t_cmd *cmd, t_ms *ms)
+void	execute_single_cmd(t_cmd *cmd, t_ms *ms) ///t_token *token?
 {
 	pid_t	pid;
 	int		status;
+	//t_token	*cur;
 
+	//cur = token;
 	ms->exit_status = 0;
 
-	if (cmd->infile == NO_FD || cmd->outfile == NO_FD) 
+	if (cmd->infile == NO_FD || cmd->outfile == NO_FD)
 	{
 		ms->exit_status = 1;
 		return ;
 	}
-
 	pid = fork();
 	if (pid < 0)
 	{
@@ -67,6 +99,19 @@ void	execute_single_cmd(t_cmd *cmd, t_ms *ms)
 	}
 	if (pid == 0) // Child process
 	{
+		/*if (cmd->infile == -3)
+		{
+			cur = cur->next;
+			cur = cur->next;
+			if (cur)
+				handle_heredoc(cur->file);
+		}*/
+		if (cmd->infile != -2 && cmd->infile != -1)
+		{
+			if (dup2(cmd->infile, STDIN_FILENO) == -1)
+				exit(1);
+			close(cmd->infile);
+		}
 		if (is_builtin(cmd))
 		{
 			handle_builtin(cmd, ms, 0);
@@ -107,6 +152,7 @@ void	execute_cmd(int num_cmds, t_cmd *cmds, t_ms *ms)
 	pid_t   wpid;
 	int     status;
 	t_cmd	*cur;
+	//t_token	*cur2;
 
 	i = 0;
 	last_pid = -1;
@@ -119,8 +165,9 @@ void	execute_cmd(int num_cmds, t_cmd *cmds, t_ms *ms)
 	if (!pipe_fd)
 		return;
 	cur = cmds;
-
-	while (cur)//(i < num_cmds)
+	//cur2 = tokens;
+	//cur2 = cur2->next;
+	while (cur && i < num_cmds)
 	{
 		pipe_fd[i] = malloc(sizeof(int) * 2);
 		if (!pipe_fd[i])
@@ -147,12 +194,21 @@ void	execute_cmd(int num_cmds, t_cmd *cmds, t_ms *ms)
 			if (cur->infile == NO_FD || cur->outfile == NO_FD)
 				exit(1); //not sure about that!
 
-			if (i == 0) // first command
-				pipe_process(NULL, pipe_fd[i]);
-			else if (i == num_cmds - 1) // last command
-				pipe_process(pipe_fd[i - 1], NULL);
-			else //any commands in between
-				pipe_process(pipe_fd[i - 1], pipe_fd[i]);
+			//if (i == 0) // first command
+			//pipe_process(cur->infile, cur->outfile, pipe_fd[i-1], pipe_fd[i]);
+			//else if (i == num_cmds - 1) // last command
+				//pipe_process(pipe_fd[i - 1], NULL);
+			//else //any commands in between
+				//pipe_process(pipe_fd[i - 1], pipe_fd[i]);
+			//if (cmds->infile == -3)
+			//	handle_heredoc(cur->args[1]);
+			if (i == 0) // First command
+                pipe_process(cur->infile, cur->outfile, NULL, pipe_fd[i]);
+            else if (i == num_cmds - 1) // Last command
+                pipe_process(cur->infile, cur->outfile, pipe_fd[i-1], NULL);
+            else // Any commands in between
+                pipe_process(cur->infile, cur->outfile, pipe_fd[i-1], pipe_fd[i]);
+
 			if (is_builtin(cur))
 			{
 				handle_builtin(cur, ms, 1);
@@ -168,6 +224,7 @@ void	execute_cmd(int num_cmds, t_cmd *cmds, t_ms *ms)
 		}
 		last_pid = pid;
 		cur = cur->next;
+		//cur2 = cur2->next;
 		i++;
 	}
 	i = 0;

--- a/src/parser/cmd_creation.c
+++ b/src/parser/cmd_creation.c
@@ -63,6 +63,8 @@ void	redir_in_block(t_block *block, t_cmd *cmd, t_ms *ms)
 				put_infile_fd(cur, cmd);
 			else if (cur->type == OUT || cur->type == APPEND)
 				put_outfile_fd(cur, cmd);
+			else if (cur->type == HEREDOC)
+				put_heredoc_fd(cur, cmd);
 			if (cmd->infile == NO_FD || cmd->outfile == NO_FD)
 			{
 				ms->exit_status = 1;

--- a/src/parser/main.c
+++ b/src/parser/main.c
@@ -6,8 +6,8 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 
-/*
-void print_tokens(t_token *token_list)
+
+/*void print_tokens(t_token *token_list)
 {
 	t_token *cur = token_list;
 
@@ -17,8 +17,8 @@ void print_tokens(t_token *token_list)
 		printf("Type: %d, Data: %s, Quotes: %c, Redir: %d, Ambig: %d, File: %s\n", cur->type, cur->data, cur->quote, cur->specific_redir, cur->ambiguous, cur->file);
 		cur = cur->next;
 	}
-}*/
-/*
+}
+
 static void print_blocks(t_block *block_list)
 {
 	t_block *cur = block_list;
@@ -34,8 +34,8 @@ static void print_blocks(t_block *block_list)
 
 		cur = cur->next;
 	}
-}*/
-/*
+}
+
 static void print_cmds(t_cmd *cmd_list)
 {
 	t_cmd *cur = cmd_list;
@@ -159,6 +159,7 @@ int main(int argc, char **argv, char **envp)
 
 		//print_tokens(tokens);
 		put_files_for_redirections(tokens);
+		//printf("tokens again \n");
 		//print_tokens(tokens);
 
 		blocks = create_blocks_list(tokens, NULL, &err_flag);
@@ -181,6 +182,7 @@ int main(int argc, char **argv, char **envp)
 			clean_block_list(&blocks);
 			continue;
 		}
+		//print_cmds(cmds);
 		i = 0;
 		cur = cmds;
 		while (cur)

--- a/src/redirection/fds.c
+++ b/src/redirection/fds.c
@@ -74,6 +74,32 @@ void handle_heredoc(char *limiter, t_ms *ms)
 	close(temp_fd);
 }*/
 
+void	handle_heredoc(char *limiter)
+{
+	char	*read_line;
+	int		pipe_fd[2];
+
+	if (pipe(pipe_fd) == -1)
+		return;
+	while (1)
+	{
+		read_line = readline("heredoc> ");
+		if (!read_line)
+			exit(1);
+		if (ft_strcmp(read_line, limiter) == 0)
+		{
+			free(read_line);
+			break;
+		}
+		ft_putstr_fd(read_line, pipe_fd[1]);
+		write(pipe_fd[1], "\n", 1);
+		free(read_line);
+	}
+	close(pipe_fd[1]);
+	dup2(pipe_fd[0], STDIN_FILENO);
+	close(pipe_fd[0]);
+}
+
 void	check_access(char *filename, t_oper operation)
 {
 	if (operation == RD)
@@ -108,6 +134,21 @@ void	redirection_outfile_append(char *file)
 	close(file2);
 }*/
 
+void	put_heredoc_fd(t_token *token, t_cmd *cmd)
+{
+	if (cmd->infile > 0)
+	close(cmd->infile);
+	if (token->ambiguous)
+	{
+		cmd->infile = NO_FD;
+		print_file_error(token->file, AMBIG);
+	}
+	else
+	{
+		cmd->infile = -3;
+	}
+}
+
 void	put_outfile_fd(t_token *token, t_cmd *cmd)
 {
 	if (cmd->outfile > 0)
@@ -125,8 +166,8 @@ void	put_outfile_fd(t_token *token, t_cmd *cmd)
 			cmd->outfile = open(token->file, O_WRONLY | O_CREAT | O_APPEND, 0644);
 		if (cmd->outfile < 0)
 			check_access(token->file, WR);
-		dup2(cmd->outfile, STDOUT_FILENO);
-		close (cmd->outfile);
+		//dup2(cmd->outfile, STDOUT_FILENO);
+		//close (cmd->outfile);
 	}
 }
 
@@ -163,8 +204,8 @@ void	put_infile_fd(t_token *token, t_cmd *cmd)
 		//printf("infile fd %d\n", cmd->infile);
 		if (cmd->infile < 0)
 			check_access(token->file, RD);
-		dup2(cmd->infile, STDIN_FILENO);
-		close (cmd->infile);
+		//dup2(cmd->infile, STDIN_FILENO);
+		//close (cmd->infile);
 	}
 }
 /*


### PR DESCRIPTION
cat < input2 | grep "hello" > file1.txt | cat > file2.txt < input1 this works now for example correctly, before it didnt work at all. changes in structure also